### PR TITLE
Fix N/A display in dashboard results modal

### DIFF
--- a/src/app/application/layout/welcome/dashboard/dashboard.component.html
+++ b/src/app/application/layout/welcome/dashboard/dashboard.component.html
@@ -105,13 +105,13 @@
                 {{summary.sequence}}
               </td>
               <td>
-                {{summary.values[0].calculatedValue}}
+                {{summary.values[0]?.calculatedValue !== null && !isNaN(summary.values[0]?.calculatedValue) ? (summary.values[0].calculatedValue | number:'1.2-2') : '-'}}
               </td>
               <td>
-                {{summary.values[1].calculatedValue}}
+                {{summary.values[1]?.calculatedValue !== null && !isNaN(summary.values[1]?.calculatedValue) ? (summary.values[1].calculatedValue | number:'1.2-2') : '-'}}
               </td>
               <td>
-                {{summary.values[2].calculatedValue}}
+                {{summary.values[2]?.calculatedValue !== null && !isNaN(summary.values[2]?.calculatedValue) ? (summary.values[2].calculatedValue | number:'1.2-2') : '-'}}
               </td>
           </tr>
       </tbody>


### PR DESCRIPTION
## Problem
When viewing HeLa DIA files in the dashboard, the Results modal displays "N/A" for all Peak area, Mass accuracy, and Retention time values, even though BSA DIA files display correctly.

## Root Cause
The backend returns:
- **For BSA files**: Valid `calculatedValue` numbers from the database
- **For HeLa files**: Empty `values` arrays or `NaN` values when `calculatedValue` is `null` in the database

The frontend template was directly accessing `summary.values[0].calculatedValue` without handling:
1. Empty arrays (when no data exists for that peptide/file combination)
2. `NaN` values (when `calculatedValue` is `null` in the database)

## Solution
Updated `dashboard.component.html` to properly handle missing data:

```html
<!-- Before -->
{{summary.values[0].calculatedValue}}

<!-- After -->
{{summary.values[0]?.calculatedValue !== null && !isNaN(summary.values[0]?.calculatedValue) 
  ? (summary.values[0].calculatedValue | number:'1.2-2') 
  : '-'}}
```

### Changes:
- ✅ Use safe navigation operator (`?.`) to prevent undefined access errors
- ✅ Check for `null` and `NaN` values explicitly
- ✅ Display clean `-` for missing/invalid data instead of "N/A"
- ✅ Format valid numbers with 2 decimal places using Angular's `number` pipe

## Testing
After deploying this fix:
1. Select "HeLa DIA" sample type in dashboard
2. Click "Results" on any file
3. Modal should display `-` for missing values instead of "N/A"
4. Valid numeric values should display formatted with 2 decimal places

## Notes
This is a **frontend display fix**. The underlying issue of why HeLa files have missing data in the database should be investigated separately (likely a data processing/insertion issue in the backend pipeline).